### PR TITLE
🔧 Agent設定同期ワークフローを追加

### DIFF
--- a/.github/workflows/sync-agent-config.yml
+++ b/.github/workflows/sync-agent-config.yml
@@ -1,0 +1,54 @@
+name: Sync agent config
+
+on:
+  workflow_dispatch:
+  schedule:
+    # JST Monday 09:00 = UTC Monday 00:00
+    - cron: '0 0 * * 1'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-agent-config:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout current repository
+        uses: actions/checkout@v4
+
+      - name: Sync agent config from web-app-template
+        shell: bash
+        run: bash scripts/sync-agent-config.sh
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v8
+        with:
+          branch: chore/sync-agent-config
+          commit-message: 'chore: sync agent config from web-app-template'
+          title: 'chore: sync agent config from web-app-template'
+          body: |
+            web-app-template から AI agent 設定を同期します。
+
+            ## 同期対象
+
+            - .claude
+            - .agent
+            - .agents
+            - .codex
+
+            ## 補足
+
+            - web-app-template 側の内容を source of truth として同期します
+            - 同期対象ディレクトリは完全同期されます
+            - template 側に存在しないファイルは削除されます
+            - .agent-sync.lock に同期元 commit を記録します
+            - 差分がない場合、PR は作成・更新されません
+
+          add-paths: |
+            .claude
+            .agent
+            .agents
+            .codex
+            .agent-sync.lock

--- a/README.md
+++ b/README.md
@@ -223,6 +223,30 @@ pnpm dev
 pnpm -F app dev
 ```
 
+## Agent config sync
+
+このプロジェクトの `.claude` / `.agent` / `.agents` / `.codex` は、`junkisai/web-app-template` を source of truth として同期します。
+
+### 同期方法
+
+GitHub Actions の `Sync agent config` workflow により、毎週月曜に自動で同期 PR が作成されます。
+
+手動で同期したい場合は、GitHub Actions から `Sync agent config` を `workflow_dispatch` で実行してください。
+
+ローカルで同期したい場合は以下を実行します。
+
+```sh
+pnpm sync:agents
+```
+
+### 注意
+
+同期対象ディレクトリは `web-app-template` 側の内容で完全同期されます。
+
+そのため、各プロジェクト側で `.claude` / `.agent` / `.agents` / `.codex` に独自ファイルを追加していた場合、次回同期時に削除されます。
+
+共通設定を変更したい場合は、派生プロジェクトではなく `web-app-template` 側に反映してください。
+
 ## Deploy
 
 デプロイは `main` へのマージをトリガーに自動で実行されます。事前に `.env` を用意したうえで、Cloudflare の secret を次回デプロイ向けに登録してください。

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "turbo run dev",
     "lint": "turbo run lint",
     "lint:packageVersion": "syncpack list-mismatches",
-    "fmt": "turbo run fmt"
+    "fmt": "turbo run fmt",
+    "sync:agents": "bash scripts/sync-agent-config.sh"
   },
   "devDependencies": {
     "concurrently": "9.0.1",

--- a/scripts/sync-agent-config.sh
+++ b/scripts/sync-agent-config.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_REPO="${SOURCE_REPO:-https://github.com/junkisai/web-app-template.git}"
+SOURCE_BRANCH="${SOURCE_BRANCH:-main}"
+
+SYNC_DIRS=(
+  ".claude"
+  ".agent"
+  ".agents"
+  ".codex"
+)
+
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+echo "Syncing agent config from ${SOURCE_REPO}@${SOURCE_BRANCH}"
+
+git clone \
+  --depth=1 \
+  --filter=blob:none \
+  --sparse \
+  --branch "$SOURCE_BRANCH" \
+  "$SOURCE_REPO" \
+  "$TMP_DIR"
+
+git -C "$TMP_DIR" sparse-checkout set "${SYNC_DIRS[@]}"
+
+for dir in "${SYNC_DIRS[@]}"; do
+  if [ -d "$TMP_DIR/$dir" ]; then
+    echo "Syncing $dir"
+
+    mkdir -p "$dir"
+
+    rsync -a --delete \
+      "$TMP_DIR/$dir/" \
+      "$dir/"
+  else
+    echo "Skip $dir because it does not exist in source repository"
+  fi
+done
+
+SOURCE_COMMIT="$(git -C "$TMP_DIR" rev-parse HEAD)"
+
+cat > .agent-sync.lock <<EOF
+source_repo: junkisai/web-app-template
+source_branch: ${SOURCE_BRANCH}
+source_commit: ${SOURCE_COMMIT}
+synced_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+synced_dirs:
+$(printf '  - %s\n' "${SYNC_DIRS[@]}")
+EOF
+
+echo "Synced from ${SOURCE_COMMIT}"


### PR DESCRIPTION
## 変更概要

- `web-app-template` の `.claude` / `.agent` / `.agents` / `.codex` を派生プロジェクトへ完全同期するスクリプトを追加
- 毎週月曜 09:00 JST と手動実行で同期 PR を作成する GitHub Actions workflow を追加
- `pnpm sync:agents` でローカル同期できる npm script を追加
- README に同期対象、実行方法、完全同期による削除ルールを追記

## 背景

派生プロジェクト側の AI agent 設定を、手動コピーではなく `web-app-template` を source of truth として追従できるようにするためです。

## アプローチ

`rsync --delete` により同期対象ディレクトリを template 側の内容で完全同期し、差分がある場合だけ `peter-evans/create-pull-request` でレビュー可能な PR を作成します。

## スクリーンショット

UI 変更はありません。
